### PR TITLE
Update calibration makefile

### DIFF
--- a/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
+++ b/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
@@ -1,6 +1,10 @@
 # Makefile for calibration process
 
-all: inputs/activation.dat all_frames outputs/figures/speed outputs/figures/activation_rate outputs/data
+all: all_inputs all_figures outputs/frames outputs/data outputs/models
+
+all_inputs: inputs/activation.dat all_frames
+
+all_figures: outputs/figures/speed outputs/figures/activation_rate outputs/figures/sensitivity_analysis
 
 inputs/activation.dat: ../grand_central_terminal_data/GCT_final_real_data/activation.dat
 	cp ../grand_central_terminal_data/GCT_final_real_data/activation.dat inputs/activation.dat
@@ -29,5 +33,14 @@ outputs/figures/speed: outputs/figures
 outputs/figures/activation_rate: outputs/figures
 	cd outputs/figures/ && mkdir activation_rate
 
+outputs/frames:
+	cd outputs/ && mkdir frames
+
 outputs/data:
 	cd outputs/ && mkdir data
+
+outputs/figures/sensitivity_analysis:
+	cd outputs/figures/ && mkdir sensitivity_analysis
+
+outputs/models:
+	cd outputs/ && mkdir models

--- a/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
+++ b/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
@@ -4,7 +4,11 @@ all: all_inputs all_figures outputs/frames outputs/data outputs/models
 
 all_inputs: inputs/activation.dat all_frames
 
-all_figures: outputs/figures/speed outputs/figures/activation_rate outputs/figures/sensitivity_analysis
+all_figures: all_calibration_figs all_sa_figs
+
+all_calibration_figs: outputs/figures/speed outputs/figures/activation_rate
+
+all_sa_figs: outputs/figures/sensitivity_analysis/local outputs/figures/sensitivity_analysis/global
 
 inputs/activation.dat: ../grand_central_terminal_data/GCT_final_real_data/activation.dat
 	cp ../grand_central_terminal_data/GCT_final_real_data/activation.dat inputs/activation.dat
@@ -39,8 +43,14 @@ outputs/frames:
 outputs/data:
 	cd outputs/ && mkdir data
 
-outputs/figures/sensitivity_analysis:
+outputs/figures/sensitivity_analysis: outputs/figures
 	cd outputs/figures/ && mkdir sensitivity_analysis
+
+outputs/figures/sensitivity_analysis/local: outputs/figures/sensitivity_analysis
+	cd outputs/figures/sensitivity_analysis && mkdir local
+
+outputs/figures/sensitivity_analysis/global: outputs/figures/sensitivity_analysis
+	cd outputs/figures/sensitivity_analysis && mkdir global
 
 outputs/models:
 	cd outputs/ && mkdir models

--- a/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
+++ b/Projects/ABM_DA/experiments/stationsim_gcs_calibration/Makefile
@@ -1,6 +1,6 @@
 # Makefile for calibration process
 
-all: inputs/activation.dat all_frames
+all: inputs/activation.dat all_frames outputs/figures/speed outputs/figures/activation_rate outputs/data
 
 inputs/activation.dat: ../grand_central_terminal_data/GCT_final_real_data/activation.dat
 	cp ../grand_central_terminal_data/GCT_final_real_data/activation.dat inputs/activation.dat
@@ -19,3 +19,15 @@ zip_outputs:
 
 unzip_outputs:
 	tar -xzf all_outputs.tar.gz outputs/
+
+outputs/figures:
+	cd outputs/ && mkdir figures
+
+outputs/figures/speed: outputs/figures
+	cd outputs/figures/ && mkdir speed
+
+outputs/figures/activation_rate: outputs/figures
+	cd outputs/figures/ && mkdir activation_rate
+
+outputs/data:
+	cd outputs/ && mkdir data


### PR DESCRIPTION
When running experiments to calibrate stationsim for my PhD, I created a Makefile to automate some of the data setup. This Makefile was missing a couple of rules. This PR adds the missing rules:

* Add rules for creating output figure dirs
* Add rule for creating output data dir